### PR TITLE
Always comape to buffer_len to allow subcommand completion

### DIFF
--- a/src/slash.c
+++ b/src/slash.c
@@ -434,7 +434,7 @@ static void slash_complete(struct slash *slash)
 
 	slash_for_each_command(cmd) {
 
-		if (strncmp(slash->buffer, cmd->name, slash_min(strlen(cmd->name), buffer_len)) == 0) {
+		if (strncmp(slash->buffer, cmd->name, buffer_len) == 0) {
 
 			/* Count matches */
 			matches++;


### PR DESCRIPTION
If this is changed to always compare using the length of what has been typed in it will allow for completion of sub-commands such as:
- "list d\t" -> "list download"
- "list s\t" -> "list save"