### PR TITLE
Expose slash_build_args()

### DIFF
--- a/src/slash.c
+++ b/src/slash.c
@@ -284,7 +284,7 @@ slash_command_find(struct slash *slash, char *line, size_t linelen, char **args)
 	return max_match_cmd;
 }
 
-static int slash_build_args(char *args, char **argv, int *argc)
+int slash_build_args(char *args, char **argv, int *argc)
 {
 	/* Quote level */
 	enum {


### PR DESCRIPTION
PyCSH can make use of this function to avoid infinite recursion from slash_execute() (in commit: [57e7999](https://github.com/spaceinventor/PyCSH/tree/57e7999f1e777febf001dfbb57ebea07e142570a)), when calling overridden slash commands.
I am making this a PR, as to ask whether we frown heavily on exposing inner workings like this.