### PR TITLE
Feature/add-environment-variables-handling

### DIFF
--- a/include/slash/slash.h
+++ b/include/slash/slash.h
@@ -208,6 +208,17 @@ char *slash_readline(struct slash *slash);
  */
 void slash_on_execute_hook(const char *line);
 
+
+typedef char *(*slash_process_cmd_line_hook_t)(const char *line);
+/**
+ * @brief Set this variable to a function if you whish to modify the command line about to be executed
+ * 
+ * @param line the slash line about to be executed
+ * @return a malloc'ed pointer to the processed command line, this will be free()'d for you, NULL is a valid
+ * return value and will cause the original line to be used as-is.
+ */
+extern slash_process_cmd_line_hook_t slash_process_cmd_line_hook;
+
 int slash_execute(struct slash *slash, char *line);
 
 int slash_loop(struct slash *slash);

--- a/include/slash/slash.h
+++ b/include/slash/slash.h
@@ -211,7 +211,7 @@ void slash_on_execute_hook(const char *line);
 
 typedef char *(*slash_process_cmd_line_hook_t)(const char *line);
 /**
- * @brief Set this variable to a function if you whish to modify the command line about to be executed
+ * @brief Set this variable to a function if you wish to modify the command line about to be executed
  * 
  * @param line the slash line about to be executed
  * @return a malloc'ed pointer to the processed command line, this will be free()'d for you, NULL is a valid

--- a/include/slash/slash.h
+++ b/include/slash/slash.h
@@ -219,6 +219,12 @@ typedef char *(*slash_process_cmd_line_hook_t)(const char *line);
  */
 extern slash_process_cmd_line_hook_t slash_process_cmd_line_hook;
 
+/**
+ * @brief Set this variable to a function if you wish to execute general completions after specific completions have been executed
+ * @see slash_completer_func_t
+ */
+extern slash_completer_func_t slash_global_completer;
+
 int slash_execute(struct slash *slash, char *line);
 
 int slash_loop(struct slash *slash);

--- a/src/completer.c
+++ b/src/completer.c
@@ -143,6 +143,8 @@ struct completion_entry {
     SLIST_ENTRY(completion_entry) list;
 };
 
+slash_completer_func_t slash_global_completer = NULL;
+
 /**
  * @brief For tab auto completion, calls other completion functions when matched command has them
  *
@@ -233,6 +235,9 @@ void slash_complete(struct slash *slash)
                 strcpy(args, slash->buffer + cmd_len + 1);
                 slash_build_args(args, slash->argv, &slash->argc);
                 completion->cmd->completer(slash, slash->buffer + cmd_len + 1);
+                if (slash_global_completer) {
+                    slash_global_completer(slash, slash->buffer + cmd_len + 1);
+                }
             }
         }
     } else if(matches > 1) {
@@ -244,6 +249,10 @@ void slash_complete(struct slash *slash)
             strncpy(slash->buffer, completion->cmd->name, prefix_len);
             slash->buffer[prefix_len] = '\0';
             slash->cursor = slash->length = strlen(slash->buffer);
+        }
+    } else {
+        if (slash_global_completer) {
+            slash_global_completer(slash, slash->buffer);
         }
     }
     /* Free up the completion list we built up earlier */

--- a/src/slash.c
+++ b/src/slash.c
@@ -372,7 +372,7 @@ int slash_execute(struct slash *slash, char *line)
 {
 	struct slash_command *command;
 	char *args, *argv[SLASH_ARG_MAX];
-	char *processed_cmd_line, *line_to_use;
+	char *processed_cmd_line = NULL, *line_to_use;
 	int ret, argc = 0;
 
 	/* Skip comments */

--- a/src/slash.c
+++ b/src/slash.c
@@ -366,10 +366,13 @@ __attribute__((weak)) int slash_prompt(struct slash *slash) {
 	return 0;
 }
 
+slash_process_cmd_line_hook_t slash_process_cmd_line_hook  = NULL;
+
 int slash_execute(struct slash *slash, char *line)
 {
 	struct slash_command *command;
 	char *args, *argv[SLASH_ARG_MAX];
+	char *processed_cmd_line, *line_to_use;
 	int ret, argc = 0;
 
 	/* Skip comments */
@@ -377,9 +380,22 @@ int slash_execute(struct slash *slash, char *line)
 		return SLASH_SUCCESS;
 	}
 
-	command = slash_command_find(slash, line, strlen(line), &args);
+	if(NULL != slash_process_cmd_line_hook) {
+		processed_cmd_line = slash_process_cmd_line_hook(line);
+	}
+
+	if (processed_cmd_line != NULL) {
+		line_to_use = processed_cmd_line;
+	} else {
+		line_to_use = line;
+	}
+
+	command = slash_command_find(slash, line_to_use, strlen(line_to_use), &args);
 	if (!command) {
+		/* Print the original line here, not the possibly processed one */
 		slash_printf(slash, "No such command: %s\n", line);
+		/* Yes, processed_cmd_line maybe NULL, but the man page says it's ok, so we save an "if" statement */
+		free(processed_cmd_line);
 		return -ENOENT;
 	}
 
@@ -387,12 +403,16 @@ int slash_execute(struct slash *slash, char *line)
 	slash_on_execute_hook(line);
 
 	if (!command->func) {
+		/* Yes, processed_cmd_line maybe NULL, but the free() man page says it's ok, so we save an "if" statement */
+		free(processed_cmd_line);
 		return -EINVAL;
 	}
 
 	/* Build args */
 	if (slash_build_args(args, argv, &argc) < 0) {
 		slash_printf(slash, "Mismatched quotes\n");
+		/* Yes, processed_cmd_line maybe NULL, but the free() man page says it's ok, so we save an "if" statement */
+		free(processed_cmd_line);
 		return -EINVAL;
 	}
 
@@ -407,9 +427,13 @@ int slash_execute(struct slash *slash, char *line)
 	slash->argv = argv;
 	ret = command->func(slash);
 
+
+
 	if (ret == SLASH_EUSAGE)
 		slash_command_usage(slash, command);
 
+	/* Yes, processed_cmd_line maybe NULL, but the free() man page says it's ok, so we save an "if" statement */
+	free(processed_cmd_line);
 	return ret;
 }
 


### PR DESCRIPTION
Add a runtime configurable hook to allow modification of the command line about to be executed.
Modification in this context could be expanding references to environment variables.