### PR TITLE
Progressive removal of CSH specifics

### DIFF
--- a/include/slash/dflopt.h
+++ b/include/slash/dflopt.h
@@ -1,5 +1,9 @@
 #pragma once
 
+/* TODO: determine when to enable this */
+#if 0
+#pragma GCC warning "dflopt.h is deprecated, use  #include <apm/csh_api.h> instead"
+#endif
 #include <slash/slash.h>
 #include <slash/optparse.h>
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -5,7 +5,6 @@
 #include <time.h>
 
 #include <slash/slash.h>
-#include <slash/dflopt.h>
 #include <slash/optparse.h>
 #include <slash/completer.h>
 


### PR DESCRIPTION
- add currently not active warning in anticipation of dflopt.h header deprecation
- remove unneed header inclusion