### PR TITLE
Added customizable context pointer to `struct slash_command`

### DIFF
--- a/include/slash/slash.h
+++ b/include/slash/slash.h
@@ -97,6 +97,7 @@
 /* Command prototype */
 struct slash;
 typedef int (*slash_func_t)(struct slash *slash);
+typedef int (*slash_func_context_t)(struct slash *slash, void *context);
 
 /* Wait function prototype,
  * this function is implemented by user, so use a void* instead of struct slash* */
@@ -120,7 +121,12 @@ typedef void (*slash_completer_func_t)(struct slash *slash, char * token);
 struct slash_command {
 	/* Static data */
 	char *name;
-	const slash_func_t func;
+	union {
+		/* Traditional function used by the `slash_command()` macros. */
+		const slash_func_t func;
+		/* Function with context pointer, for advanced API usage. */
+		const slash_func_context_t func_ctx;
+	};
 	const char *args;
 	const char *help;
 	const slash_completer_func_t completer;
@@ -129,6 +135,10 @@ struct slash_command {
 	/* single linked list:
 	 * The weird definition format comes from sys/queue.h SLINST_ENTRY() macro */
     struct { struct slash_command *sle_next; } next;
+	
+	/* Optional context pointer (after `next` for ABI compatibility).
+		Will be supplied to `func_ctx` if specified.  */
+	void *context;
 };
 
 /* Slash context */

--- a/src/slash.c
+++ b/src/slash.c
@@ -459,9 +459,14 @@ int slash_execute(struct slash *slash, char *line)
 
 	slash->argc = argc;
 	slash->argv = argv;
-	ret = command->func(slash);
-
-
+	if (command->context) {
+		/* If the user has attached context to the command,
+			we assume they also specified a function which can accept it. */
+		ret = command->func_ctx(slash, command->context);
+	} else {
+		/* Otherwise call the traditional (`slash_command()` macro) function without context. */
+		ret = command->func(slash);
+	}
 
 	if (ret == SLASH_EUSAGE)
 		slash_command_usage(slash, command);


### PR DESCRIPTION
Currently no function to use it, but a struct initializer will suffice.

Using [PyCSH](https://github.com/spaceinventor/pycsh_core/blob/69c88f879c136fec17be74807fee75f4dec0fdce/src/slash_command/python_slash_command.c#L862) as an example:
```

int SlashCommand_func(struct slash *slash, void *context);

const struct slash_command temp_command = {
    ...
    .name = strdup(name),
    .func_ctx = SlashCommand_func,
    .context = (void *)self,  // We will use this to find the PythonSlashCommandObject instance
    ...
};

...

int res = slash_list_add(&self->command_heap);
...

```